### PR TITLE
Allow building with GHC 9.2

### DIFF
--- a/kvitable.cabal
+++ b/kvitable.cabal
@@ -46,9 +46,9 @@ library
                      , Data.KVITable.Render.ASCII
                      , Data.KVITable.Render.HTML
   -- other-modules:
-  build-depends:       base >=4.12 && <4.16
+  build-depends:       base >=4.12 && <4.17
                      , containers >= 0.6 && < 0.7
-                     , lucid  >= 2.9 && < 2.10
+                     , lucid  >= 2.9 && < 2.12
                      , microlens >= 0.4 && < 0.5
                      , prettyprinter >= 1.7 && < 1.8
                      , text >= 1.2 && < 1.3


### PR DESCRIPTION
This raises the upper version bounds on `base` and `lucid` to allow `kvitable` to build with `base-4.16.*` (GHC 9.2).