### PR TITLE
Implement `insertWith` and `foldlInsertWith`

### DIFF
--- a/test/TestMain.hs
+++ b/test/TestMain.hs
@@ -165,6 +165,18 @@ main = defaultMain $
                           , ([ "baz", "beam", "woof"], "yo")
                           ]
 
+         , testCaseSteps "insertWith" $ \step ->
+             do
+               let keyvals = [ ("foo", "bar"), ("moo", "cow") ]
+
+               step "inserting a new value"
+               let t1 = insertWith (<>) keyvals "old" kvi0
+               Just "old" @=? lookup keyvals t1
+
+               step "combining with an existing value"
+               let t2 = insertWith (<>) keyvals "new" t1
+               Just "newold" @=? lookup keyvals t2
+
          , testCase "medium sized table rows" $
            rows mediumKVI @?=
            [ ([ "gcc7", "yes", "0"], "good" )


### PR DESCRIPTION
Though `insertWith` can be defined by appealing to the library's existing primitives, a native implementation like this ought to be more performant. This is intended to mimic [`Data.Map.insertWith`](https://hackage.haskell.org/package/containers-0.6.5.1/docs/Data-Map-Lazy.html#v:insertWith)'s behavior, including the order of arguments provided to the combination function.